### PR TITLE
King's look alike fix

### DIFF
--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -1003,11 +1003,11 @@ export const achievements = [
     {
         id: "hippocracy",
         title: "Hippocracy",
-        description: "Disable King's Look-Alike with sabotage card (Undercover Mission/The Mole) before revealing the Usurper. Damage remaining king to reveal Usurper, letting knights rule.",
+        description: "Disable King's Look-alike with sabotage card (Undercover Mission/The Mole) before revealing the Usurper. Damage remaining king to reveal Usurper, letting knights rule.",
         progress: 0,
         maxProgress: 1,
         completed: false,
-        requiredCards: ["King's Look-Alike", "Undercover Mission", "The Mole"],
+        requiredCards: ["King's Look-alike", "Undercover Mission", "The Mole"],
         difficulty: "Hard"
     },
     {

--- a/src/data/cards.js
+++ b/src/data/cards.js
@@ -27,7 +27,7 @@ export const allCards = [
     "Divine Healing", "Last Guardian", "Trowel", "Full Plate Armor", "Military Academy",
     "Witch's Curse", "Saddle", "The Jester", "Guillotine", "Analysis Paralysis", "Mausoleum",
     "Final Countdown", "Mangonel", "Prison", "The Royal Hunt", "Buckler of Limos",
-    "King's Look-Alike", "Emergency Call", "Lady in the Tower", "Vampirism", "Inquisition",
+    "King's Look-alike", "Emergency Call", "Lady in the Tower", "Vampirism", "Inquisition",
     "Tag Team", "Unsettled Throne", "Nomad Life", "Governess", "Unicorn", "Plumed Knight",
     "Reverend Mother", "Commoner's Reign", "Self Defense", "Bouncy Castle", "Sokoban",
     "Fallen Dynasty"


### PR DESCRIPTION
Similar to the Wand of hypnosis, the difference in capitalization is preventing the achievements Anarchy and Hidden Conspirator from being associated to King's Look-alike